### PR TITLE
Use user icon for Kevin Zheng website

### DIFF
--- a/content/authors/kevin-zheng/_index.md
+++ b/content/authors/kevin-zheng/_index.md
@@ -49,6 +49,9 @@ social:
 - icon: linkedin
   icon_pack: fab
   link: https://www.linkedin.com/in/kevin-zheng-873686274/
+- icon: user
+  icon_pack: fas
+  link: https://kyxzhe.github.io
 
 # Link to a PDF of your resume/CV from the About widget.
 # To enable, copy your resume/CV to `static/files/cv.pdf` and uncomment the lines below.


### PR DESCRIPTION
## Summary
- change Kevin Zheng's personal website link to use the user icon in his author profile

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922e5117c60832fabbef37783915d2c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add a “user” icon social link to Kevin Zheng’s author profile pointing to his personal website.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1a9a9bb3f9e45244d5cc347bcf7c41eb206b576a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->