### PR TITLE
Update 2026 reading schedule entry for Emily Booth

### DIFF
--- a/assets/reading/reading_group_schedule.csv
+++ b/assets/reading/reading_group_schedule.csv
@@ -4,7 +4,7 @@ Date,Presenter,Paper,Why should we care,Appear in,Repo,Blogs
 11/02/26,[Huixiang (Freda) Fu](../authors/huixiang-fu/),[LLMs+Persona-Plug = Personalized LLMs](https://aclanthology.org/2025.acl-long.461.pdf),,[ACL'25](https://2025.aclweb.org),,
 18/02/26,[Andrew Savchenko](../authors/andrew-savchenko/),CA1 mock presentation (simulated talk),,,,
 25/02/26,[Jooyoung Lee](../authors/jooyoung-lee/),[How does Misinformation Affect Large Language Model Behaviors and Preferences?](https://arxiv.org/pdf/2505.21608),,[ACL'25](https://2025.aclweb.org),,
-04/03/26,[Emily Booth](../authors/emily-booth/),,,,,
+04/03/26,[Emily Booth](../authors/emily-booth/),[Picturing Opaque Power: How Conspiracy Theorists Construct Oppositional Videos on YouTube](https://journals.sagepub.com/doi/10.1177/20563051221089568),,[Social Media + Society](https://journals.sagepub.com/home/SMS),,
 11/03/26,Artur Grigorev,,,,,
 18/03/26,[Tien An Vu](../authors/tienan-vu/),,,,,
 25/03/26,[Natalie Michael](../authors/natalie-michael/),,,,,


### PR DESCRIPTION
## Summary
- Updated the 04/03/26 reading-group entry for Emily Booth in the 2026 schedule
- Added the paper title and DOI link:
  - *Picturing Opaque Power: How Conspiracy Theorists Construct Oppositional Videos on YouTube*
  - https://journals.sagepub.com/doi/10.1177/20563051221089568
- Added the publication venue link:
  - *Social Media + Society*
  - https://journals.sagepub.com/home/SMS

## Files changed
- `assets/reading/reading_group_schedule.csv` (symlinked from `content/reading/reading_group_schedule.csv`)

## Notes
- No tests were run (content-only CSV update).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a77fd9e52c832f8ee86663c17f855c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: content-only update to a CSV schedule entry with no code or logic changes.
> 
> **Overview**
> Updates the `04/03/26` reading-group schedule entry for Emily Booth to include the selected paper title with DOI link and adds the publication venue link (`Social Media + Society`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25defa274bcb1e08a37f8f4c9b2e7f531b8cdd89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->